### PR TITLE
Restore use of KotlinModule.

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.21" />
+    <option name="version" value="1.8.22" />
   </component>
 </project>

--- a/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/FeedFetcherModule.kt
+++ b/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/FeedFetcherModule.kt
@@ -1,12 +1,12 @@
 package com.kurtraschke.gtfsrtarchiver.archiver.modules
 
-import com.google.inject.AbstractModule
 import com.kurtraschke.gtfsrtarchiver.archiver.DefaultFeedFetcher
 import com.kurtraschke.gtfsrtarchiver.archiver.FeedFetcher
+import dev.misfitlabs.kotlinguice4.KotlinModule
 import jakarta.inject.Singleton
 
-class FeedFetcherModule : AbstractModule() {
+class FeedFetcherModule : KotlinModule() {
     override fun configure() {
-        bind(FeedFetcher::class.java).to(DefaultFeedFetcher::class.java).`in`(Singleton::class.java)
+        bind<FeedFetcher>().to<DefaultFeedFetcher>().`in`<Singleton>()
     }
 }

--- a/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/OkHttpClientModule.kt
+++ b/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/OkHttpClientModule.kt
@@ -1,15 +1,15 @@
 package com.kurtraschke.gtfsrtarchiver.archiver.modules
 
-import com.google.inject.AbstractModule
+import dev.misfitlabs.kotlinguice4.KotlinModule
 import jakarta.inject.Inject
 import jakarta.inject.Named
 import jakarta.inject.Provider
 import jakarta.inject.Singleton
 import okhttp3.OkHttpClient
 
-class OkHttpClientModule : AbstractModule() {
+class OkHttpClientModule : KotlinModule() {
     override fun configure() {
-        bind(OkHttpClient::class.java).toProvider(OkHttpClientProvider::class.java).`in`(Singleton::class.java)
+        bind<OkHttpClient>().toProvider<OkHttpClientProvider>().`in`<Singleton>()
     }
 }
 

--- a/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/ProjectVersionModule.kt
+++ b/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/ProjectVersionModule.kt
@@ -1,10 +1,10 @@
 package com.kurtraschke.gtfsrtarchiver.archiver.modules
 
-import com.google.inject.AbstractModule
 import com.google.inject.name.Names
+import dev.misfitlabs.kotlinguice4.KotlinModule
 import java.util.*
 
-class ProjectVersionModule : AbstractModule() {
+class ProjectVersionModule : KotlinModule() {
     override fun configure() {
         val properties = Properties()
         ProjectVersionModule::class.java.getResourceAsStream("/maven-version.properties").use { properties.load(it) }

--- a/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/QuartzSchedulerModule.kt
+++ b/archiver/src/main/kotlin/com/kurtraschke/gtfsrtarchiver/archiver/modules/QuartzSchedulerModule.kt
@@ -1,17 +1,17 @@
 package com.kurtraschke.gtfsrtarchiver.archiver.modules
 
-import com.google.inject.AbstractModule
 import com.kurtraschke.gtfsrtarchiver.archiver.GuiceJobFactory
 import com.kurtraschke.gtfsrtarchiver.archiver.listeners.SchedulerShutdownListener
+import dev.misfitlabs.kotlinguice4.KotlinModule
 import jakarta.inject.Inject
 import jakarta.inject.Provider
 import jakarta.inject.Singleton
 import org.quartz.Scheduler
 import org.quartz.impl.StdSchedulerFactory
 
-class QuartzSchedulerModule : AbstractModule() {
+class QuartzSchedulerModule : KotlinModule() {
     override fun configure() {
-        bind(Scheduler::class.java).toProvider(QuartzSchedulerProvider::class.java).`in`(Singleton::class.java)
+        bind<Scheduler>().toProvider<QuartzSchedulerProvider>().`in`<Singleton>()
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
             <dependency>
                 <groupId>dev.misfitlabs.kotlinguice4</groupId>
                 <artifactId>kotlin-guice</artifactId>
-                <version>1.6.0</version>
+                <version>3.0.0</version>
             </dependency>
 
             <!-- slf4j -->


### PR DESCRIPTION
Put `KotlinModule` back now that `kotlin-guice` has been upgraded.

Fixes #114.